### PR TITLE
Add state and SPI address to keep the resolution of rotary encoder.

### DIFF
--- a/Core/Inc/state.h
+++ b/Core/Inc/state.h
@@ -17,6 +17,7 @@ typedef struct {
 	uint8_t control_mode;
 	float control_target;
 	float motor_supply_voltage;
+	uint32_t motor_encoder_resolution;
 	float current_fbparam_Kp;
 	float current_fbparam_Ti;
 	float speed_fbparam_Kp;

--- a/Core/Src/encoder.c
+++ b/Core/Src/encoder.c
@@ -54,13 +54,11 @@ void encoder_clear_count(const uint8_t channel) {
 	case ENCODER1:
 		__HAL_TIM_SET_COUNTER(&htim2, 0);
 		ofuf_count[ENCODER1] = 0;
-
 		break;
 
 	case ENCODER2:
 		__HAL_TIM_SET_COUNTER(&htim3, 0);
 		ofuf_count[ENCODER2] = 0;
-
 		break;
 
 	default:
@@ -73,7 +71,6 @@ void encoder_set_pulse_per_rev(const uint8_t channel, const uint16_t ppr) {
 	case ENCODER1:
 	case ENCODER2:
 		pulse_per_rev[channel] = ppr;
-
 		break;
 
 	default:

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -120,13 +120,9 @@ int main(void)
 	/* State initialize */
 	extern STATE state[];
 
-	encoder_set_pulse_per_rev(ENCODER1, 2000);
-	encoder_set_pulse_per_rev(ENCODER2, 2000);
 	encoder_start();
-
 	pwm_start();
 	csa_start();
-
 	spi_start();
   /* USER CODE END 2 */
 
@@ -139,6 +135,10 @@ int main(void)
 		/* TEST CODE END */
 
 		/* Updating state */
+		encoder_set_pulse_per_rev(ENCODER1,
+				state[MOTOR1].motor_encoder_resolution);
+		encoder_set_pulse_per_rev(ENCODER2,
+				state[MOTOR2].motor_encoder_resolution);
 		pwm_set_supply_voltage(PWM1, state[MOTOR1].motor_supply_voltage);
 		pwm_set_supply_voltage(PWM2, state[MOTOR2].motor_supply_voltage);
 		state[MOTOR1].motor_current = csa_get_current(CSA1);

--- a/Core/Src/pwm.c
+++ b/Core/Src/pwm.c
@@ -22,7 +22,6 @@ void pwm_set_supply_voltage(const uint8_t channel, const float voltage) {
 	case PWM1:
 	case PWM2:
 		supply_voltage[channel] = saturation(voltage, 1.0F, voltage);
-
 		break;
 
 	default:
@@ -50,7 +49,6 @@ void pwm_set_voltage(const uint8_t channel, const float voltage) {
 				supply_voltage[PWM1]);
 		__HAL_TIM_SET_COMPARE(&htim15, TIM_CHANNEL_1,
 				(uint32_t ) ((float) REG_ZERO * (1.0F + target_voltage / supply_voltage[PWM1])));
-
 		break;
 
 	case PWM2:
@@ -58,7 +56,6 @@ void pwm_set_voltage(const uint8_t channel, const float voltage) {
 				supply_voltage[PWM2]);
 		__HAL_TIM_SET_COMPARE(&htim16, TIM_CHANNEL_1,
 				(uint32_t ) ((float) REG_ZERO * (1.0F + target_voltage / supply_voltage[PWM2])));
-
 		break;
 
 	default:

--- a/Core/Src/spi.c
+++ b/Core/Src/spi.c
@@ -15,7 +15,7 @@ typedef enum {
 	SPI_ADDR_CONTROL_MODE,
 	SPI_ADDR_CONTROL_TARGET,
 	SPI_ADDR_MOTOR_SUPPLY_VOLTAGE,
-	SPI_ADDR_RESERVED_1,
+	SPI_ADDR_MOTOR_ENCODER_RESOLUTION,
 	SPI_ADDR_CURRENT_FB_KP,
 	SPI_ADDR_CURRENT_FB_TI,
 	SPI_ADDR_SPEED_FB_KP,
@@ -93,6 +93,7 @@ static ErrorStatus spi_check_rdata_address(const SPI_ADDR addr) {
 	case SPI_ADDR_CONTROL_MODE:
 	case SPI_ADDR_CONTROL_TARGET:
 	case SPI_ADDR_MOTOR_SUPPLY_VOLTAGE:
+	case SPI_ADDR_MOTOR_ENCODER_RESOLUTION:
 	case SPI_ADDR_CURRENT_FB_KP:
 	case SPI_ADDR_CURRENT_FB_TI:
 	case SPI_ADDR_SPEED_FB_KP:
@@ -121,6 +122,10 @@ static void spi_update_state_sub(STATE state[], const SPI_DATA *wdata,
 
 	case SPI_ADDR_MOTOR_SUPPLY_VOLTAGE:
 		state->motor_supply_voltage = wdata->f32;
+		break;
+
+	case SPI_ADDR_MOTOR_ENCODER_RESOLUTION:
+		state->motor_encoder_resolution = wdata->u32;
 		break;
 
 	case SPI_ADDR_CURRENT_FB_KP:
@@ -158,7 +163,6 @@ static void spi_update_state_sub(STATE state[], const SPI_DATA *wdata,
 		} else {
 			/* Keep current address if request address is invalid */
 		}
-
 		break;
 
 	default:
@@ -195,6 +199,10 @@ static void spi_update_DR_RDATA(SPI_DATA *rdata, const STATE *state) {
 
 	case SPI_ADDR_MOTOR_SUPPLY_VOLTAGE:
 		rdata->f32 = state->motor_supply_voltage;
+		break;
+
+	case SPI_ADDR_MOTOR_ENCODER_RESOLUTION:
+		rdata->u32 = state->motor_encoder_resolution;
 		break;
 
 	case SPI_ADDR_CURRENT_FB_KP:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 | 0 | 1 | 0 | 0 | Control mode |
 | 0 | 1 | 0 | 1 | Control target |
 | 0 | 1 | 1 | 0 | Motor supply voltage |
-| 0 | 1 | 1 | 1 | Reserved |
+| 0 | 1 | 1 | 1 | Motor encoder resolution |
 | 1 | 0 | 0 | 0 | Current feedback parameter Kp |
 | 1 | 0 | 0 | 1 | Current feedback parameter Ti |
 | 1 | 0 | 1 | 0 | Speed feedback parameter Kp |
@@ -118,6 +118,12 @@
 | Bit | Description |
 | - | - |
 | DATA31-DATA0 | Supply voltage (V) as 32bit float |
+
+#### Motor encoder resolution
+
+| Bit | Description |
+| - | - |
+| DATA31-DATA0 | Encoder resolution (pulse/rev) as 32bit unsigned integer |
 
 #### Feedback parameters
 


### PR DESCRIPTION
Modified state class and SPI class so that the encoder resolution can be set via SPI.